### PR TITLE
Changed package version for Android

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
         "react-native-elements": "^3.4.3",
         "react-native-gesture-handler": "^1.0.9",
         "react-native-keyboard-aware-scroll-view": "^0.9.5",
-        "react-native-plaid-link-sdk": "^8.0.0",
+        "react-native-plaid-link-sdk": "^10.6.3",
         "react-native-reanimated": "^3.4.2",
         "react-native-safe-area-context": "^4.7.2",
         "react-native-screens": "^3.25.0",
@@ -10677,12 +10677,15 @@
       }
     },
     "node_modules/react-native-plaid-link-sdk": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-plaid-link-sdk/-/react-native-plaid-link-sdk-8.0.1.tgz",
-      "integrity": "sha512-feKnqx3PY738LwqmiGRhJ1Dxn2tDdEOScS3CLemfNvM94jylHCkOZSmFn5SwP/IcB5pVgqlR/pnbhTQT3cPgSA==",
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/react-native-plaid-link-sdk/-/react-native-plaid-link-sdk-10.6.4.tgz",
+      "integrity": "sha512-+mVYSQgxaE4FcUGj/+9g0pDlQRGV4uMpmFf/J0hoFbrtKqUFHL+ADBNsvJ6lOGzr1aFw7R6t06BbzXsHYmcFOQ==",
+      "dependencies": {
+        "react-native-plaid-link-sdk": "^10.4.0"
+      },
       "peerDependencies": {
         "react": "*",
-        "react-native": ">=0.61"
+        "react-native": ">=0.66.0"
       }
     },
     "node_modules/react-native-ratings": {
@@ -20089,10 +20092,12 @@
       }
     },
     "react-native-plaid-link-sdk": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/react-native-plaid-link-sdk/-/react-native-plaid-link-sdk-8.0.1.tgz",
-      "integrity": "sha512-feKnqx3PY738LwqmiGRhJ1Dxn2tDdEOScS3CLemfNvM94jylHCkOZSmFn5SwP/IcB5pVgqlR/pnbhTQT3cPgSA==",
-      "requires": {}
+      "version": "10.6.4",
+      "resolved": "https://registry.npmjs.org/react-native-plaid-link-sdk/-/react-native-plaid-link-sdk-10.6.4.tgz",
+      "integrity": "sha512-+mVYSQgxaE4FcUGj/+9g0pDlQRGV4uMpmFf/J0hoFbrtKqUFHL+ADBNsvJ6lOGzr1aFw7R6t06BbzXsHYmcFOQ==",
+      "requires": {
+        "react-native-plaid-link-sdk": "^10.4.0"
+      }
     },
     "react-native-ratings": {
       "version": "8.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
     "react-native-elements": "^3.4.3",
     "react-native-gesture-handler": "^1.0.9",
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
-    "react-native-plaid-link-sdk": "^8.0.0",
+    "react-native-plaid-link-sdk": "^10.6.4",
     "react-native-reanimated": "^3.4.2",
     "react-native-safe-area-context": "^4.7.2",
     "react-native-screens": "^3.25.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6028,10 +6028,12 @@
     "prop-types" "^15.6.2"
     "react-native-iphone-x-helper" "^1.0.3"
 
-"react-native-plaid-link-sdk@^8.0.0":
-  "integrity" "sha512-feKnqx3PY738LwqmiGRhJ1Dxn2tDdEOScS3CLemfNvM94jylHCkOZSmFn5SwP/IcB5pVgqlR/pnbhTQT3cPgSA=="
-  "resolved" "https://registry.npmjs.org/react-native-plaid-link-sdk/-/react-native-plaid-link-sdk-8.0.1.tgz"
-  "version" "8.0.1"
+"react-native-plaid-link-sdk@^10.4.0", "react-native-plaid-link-sdk@^10.6.3":
+  "integrity" "sha512-+mVYSQgxaE4FcUGj/+9g0pDlQRGV4uMpmFf/J0hoFbrtKqUFHL+ADBNsvJ6lOGzr1aFw7R6t06BbzXsHYmcFOQ=="
+  "resolved" "https://registry.npmjs.org/react-native-plaid-link-sdk/-/react-native-plaid-link-sdk-10.6.4.tgz"
+  "version" "10.6.4"
+  dependencies:
+    "react-native-plaid-link-sdk" "^10.4.0"
 
 "react-native-ratings@8.0.4":
   "integrity" "sha512-Xczu5lskIIRD6BEdz9A0jDRpEck/SFxRqiglkXi0u67yAtI1/pcJC76P4MukCbT8K4BPVl+42w83YqXBoBRl7A=="
@@ -6076,7 +6078,7 @@
     "prop-types" "^15.7.2"
     "yargs" "^16.1.1"
 
-"react-native@*", "react-native@^0.0.0-0 || 0.60 - 0.72 || 1000.0.0", "react-native@>=0.42.0", "react-native@>=0.48.4", "react-native@>=0.57", "react-native@>=0.61", "react-native@0.72.4":
+"react-native@*", "react-native@^0.0.0-0 || 0.60 - 0.72 || 1000.0.0", "react-native@>=0.42.0", "react-native@>=0.48.4", "react-native@>=0.57", "react-native@>=0.66.0", "react-native@0.72.4":
   "integrity" "sha512-+vrObi0wZR+NeqL09KihAAdVlQ9IdplwznJWtYrjnQ4UbCW6rkzZJebRsugwUneSOKNFaHFEo1uKU89HsgtYBg=="
   "resolved" "https://registry.npmjs.org/react-native/-/react-native-0.72.4.tgz"
   "version" "0.72.4"


### PR DESCRIPTION
Specifically changed react-native-plaid-link-sdk as 8.0.0 does not work for Android. The app can now run for Android if the sdk is setup correctly.